### PR TITLE
fix: remove hardcoded mock data in components (#28)

### DIFF
--- a/apps/frontend/src/components/EmptyState.tsx
+++ b/apps/frontend/src/components/EmptyState.tsx
@@ -1,7 +1,7 @@
-import { Search, Filter } from 'lucide-react'
+import { Search, Filter, Heart } from 'lucide-react'
 
 interface EmptyStateProps {
-  type: 'no-results' | 'no-artworks'
+  type: 'no-results' | 'no-artworks' | 'no-favorites'
   onClearFilters?: () => void
 }
 
@@ -26,6 +26,22 @@ export function EmptyState({ type, onClearFilters }: EmptyStateProps) {
             Clear Filters
           </button>
         )}
+      </div>
+    )
+  }
+
+  if (type === 'no-favorites') {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+        <div className="w-16 h-16 bg-secondary-100 rounded-full flex items-center justify-center mb-4">
+          <Heart className="w-8 h-8 text-secondary-400" />
+        </div>
+        <h3 className="text-lg font-semibold text-secondary-900 mb-2">
+          No favorites yet
+        </h3>
+        <p className="text-secondary-600 max-w-md">
+          Heart your favorite AI artworks to save them for later and support the artists.
+        </p>
       </div>
     )
   }

--- a/apps/frontend/src/pages/ProfilePage.tsx
+++ b/apps/frontend/src/pages/ProfilePage.tsx
@@ -1,89 +1,155 @@
-import { User, Settings, Heart, ShoppingBag } from 'lucide-react'
+import { useState } from 'react'
+import { Settings, Heart, ShoppingBag } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { Grid } from '@/components/layout/Grid'
 import { ArtworkCard } from '@/components/artwork/ArtworkCard'
+import { ArtworkCardSkeleton } from '@/components/ArtworkCardSkeleton'
+import { EmptyState } from '@/components/EmptyState'
+import { useUserProfile, useUserArtworks } from '@/services/artworkService'
+import { useStellar } from '@/hooks/useStellar'
 
-// Mock data for demonstration
-const mockArtworks = Array.from({ length: 6 }, (_, i) => ({
-  id: `profile-${i + 1}`,
-  title: `AI Artwork #${i + 1}`,
-  description: 'Generated with AI Model',
-  imageUrl: '',
-  price: '0.1',
-  currency: 'ETH',
-  creator: 'Current User'
-}))
+type ActiveTab = 'created' | 'favorites'
 
 export function ProfilePage() {
-  const handleArtworkView = (artwork: typeof mockArtworks[0]) => {
-    console.log('View artwork:', artwork)
-  }
+  const [activeTab, setActiveTab] = useState<ActiveTab>('created')
 
-  const handleEditProfile = () => {
-    console.log('Edit profile')
-  }
+  const { account } = useStellar()
+  const { data: profile, isLoading: profileLoading } = useUserProfile()
+  const { data: artworks, isLoading: artworksLoading } = useUserArtworks(
+    account.publicKey || profile?.address || ''
+  )
+
+  // Display address: connected wallet key takes priority over API profile address
+  const displayAddress = account.publicKey || profile?.address || '—'
+  const displayName = profile?.username || 'Artist'
+  const stats = profile?.stats ?? { created: 0, collected: 0, favorites: 0 }
+
+  // Abbreviate long Stellar public key for display
+  const shortAddress =
+    displayAddress.length > 12
+      ? `${displayAddress.slice(0, 6)}...${displayAddress.slice(-4)}`
+      : displayAddress
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-6xl">
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+        {/* ── Sidebar ── */}
         <div className="lg:col-span-1">
           <Card padding="lg" className="text-center">
-            <div className="w-24 h-24 bg-gradient-to-br from-primary-100 to-primary-200 rounded-full mx-auto mb-4" />
-            <h2 className="text-xl font-semibold text-secondary-900">Artist Name</h2>
-            <p className="text-secondary-600 mb-4">0x1234...5678</p>
-            
+            <div className="w-24 h-24 bg-gradient-to-br from-primary-100 to-primary-200 rounded-full mx-auto mb-4 flex items-center justify-center">
+              {profile?.profileImage ? (
+                <img
+                  src={profile.profileImage}
+                  alt={displayName}
+                  className="w-full h-full object-cover rounded-full"
+                />
+              ) : (
+                <span className="text-3xl">🎨</span>
+              )}
+            </div>
+
+            {profileLoading ? (
+              <div className="animate-pulse space-y-2">
+                <div className="h-5 bg-secondary-200 rounded w-32 mx-auto" />
+                <div className="h-4 bg-secondary-100 rounded w-24 mx-auto" />
+              </div>
+            ) : (
+              <>
+                <h2 className="text-xl font-semibold text-secondary-900">{displayName}</h2>
+                <p className="text-secondary-600 mb-4 text-sm font-mono">{shortAddress}</p>
+              </>
+            )}
+
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <span className="text-secondary-600">Created</span>
-                <span className="font-medium">24</span>
+                <span className="font-medium">
+                  {profileLoading ? '—' : stats.created}
+                </span>
               </div>
               <div className="flex justify-between">
                 <span className="text-secondary-600">Collected</span>
-                <span className="font-medium">156</span>
+                <span className="font-medium">
+                  {profileLoading ? '—' : stats.collected}
+                </span>
               </div>
               <div className="flex justify-between">
                 <span className="text-secondary-600">Favorites</span>
-                <span className="font-medium">89</span>
+                <span className="font-medium">
+                  {profileLoading ? '—' : stats.favorites}
+                </span>
               </div>
             </div>
-            
+
             <div className="mt-6 space-y-2">
-              <Button variant="outline" size="md" fullWidth onClick={handleEditProfile}>
+              <Button variant="outline" size="md" fullWidth>
                 <Settings className="h-4 w-4 mr-2" />
                 Edit Profile
               </Button>
             </div>
           </Card>
         </div>
-        
+
+        {/* ── Main content ── */}
         <div className="lg:col-span-3">
           <div className="space-y-8">
-            <div>
-              <div className="flex items-center space-x-4 mb-6">
-                <button className="flex items-center space-x-2 text-primary-600 font-medium">
-                  <ShoppingBag className="h-4 w-4" />
-                  <span>Created</span>
-                </button>
-                <button className="flex items-center space-x-2 text-secondary-600">
-                  <Heart className="h-4 w-4" />
-                  <span>Favorites</span>
-                </button>
-              </div>
-              
-              <Grid columns={3} gap="md" responsive={false}>
-                {mockArtworks.map((artwork) => (
-                  <ArtworkCard
-                    key={artwork.id}
-                    artwork={artwork}
-                    variant="default"
-                    onView={handleArtworkView}
-                    showPrice={true}
-                    showCreator={false}
-                  />
-                ))}
-              </Grid>
+            {/* Tab bar */}
+            <div className="flex items-center space-x-4 mb-6">
+              <button
+                className={`flex items-center space-x-2 font-medium pb-1 border-b-2 transition-colors ${
+                  activeTab === 'created'
+                    ? 'text-primary-600 border-primary-600'
+                    : 'text-secondary-600 border-transparent'
+                }`}
+                onClick={() => setActiveTab('created')}
+              >
+                <ShoppingBag className="h-4 w-4" />
+                <span>Created</span>
+              </button>
+              <button
+                className={`flex items-center space-x-2 font-medium pb-1 border-b-2 transition-colors ${
+                  activeTab === 'favorites'
+                    ? 'text-primary-600 border-primary-600'
+                    : 'text-secondary-600 border-transparent'
+                }`}
+                onClick={() => setActiveTab('favorites')}
+              >
+                <Heart className="h-4 w-4" />
+                <span>Favorites</span>
+              </button>
             </div>
+
+            {/* Artwork grid */}
+            {activeTab === 'created' && (
+              <>
+                {artworksLoading ? (
+                  <Grid columns={3} gap="md" responsive={false}>
+                    {Array.from({ length: 6 }).map((_, i) => (
+                      <ArtworkCardSkeleton key={i} />
+                    ))}
+                  </Grid>
+                ) : artworks && artworks.length > 0 ? (
+                  <Grid columns={3} gap="md" responsive={false}>
+                    {artworks.map((artwork) => (
+                      <ArtworkCard
+                        key={artwork.id}
+                        artwork={artwork}
+                        variant="default"
+                        showPrice
+                        showCreator={false}
+                      />
+                    ))}
+                  </Grid>
+                ) : (
+                  <EmptyState type="no-artworks" />
+                )}
+              </>
+            )}
+
+            {activeTab === 'favorites' && (
+              <EmptyState type="no-favorites" />
+            )}
           </div>
         </div>
       </div>

--- a/apps/frontend/src/services/artworkService.ts
+++ b/apps/frontend/src/services/artworkService.ts
@@ -17,6 +17,19 @@ export interface Artwork {
   views?: number
 }
 
+export interface UserProfile {
+  address: string
+  username: string
+  bio: string
+  profileImage?: string
+  stats: {
+    created: number
+    collected: number
+    favorites: number
+  }
+  createdAt?: string
+}
+
 export interface ArtworksResponse {
   success: boolean
   data: Artwork[]
@@ -42,6 +55,8 @@ export interface PlatformStats {
 }
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000'
+
+// ─── Artworks ─────────────────────────────────────────────────────────────────
 
 async function fetchArtworks({
   pageParam = 1,
@@ -73,9 +88,7 @@ async function fetchArtworks({
   return data
 }
 
-export function useArtworks(
-  filters: ArtworksFilters = {},
-) {
+export function useArtworks(filters: ArtworksFilters = {}) {
   return useInfiniteQuery<ArtworksResponse, Error>(
     ['artworks', filters] as const,
     ({ pageParam = 1 }) => fetchArtworks({ pageParam: pageParam as number, filters }),
@@ -186,4 +199,53 @@ export async function getArtworkById(id: string): Promise<Artwork> {
   }
 
   return result.data
+}
+
+// ─── User Profile ─────────────────────────────────────────────────────────────
+
+async function fetchUserProfile(): Promise<UserProfile> {
+  const response = await fetch(`${API_BASE_URL}/api/users/profile`)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch user profile (Status: ${response.status})`)
+  }
+  const data = await response.json()
+  if (!data.success) {
+    throw new Error(data?.error?.message || 'Failed to fetch user profile')
+  }
+  return data.data
+}
+
+export function useUserProfile() {
+  return useQuery<UserProfile, Error>({
+    queryKey: ['user', 'profile'],
+    queryFn: fetchUserProfile,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  })
+}
+
+// ─── User Artworks ────────────────────────────────────────────────────────────
+
+async function fetchUserArtworks(creator: string): Promise<Artwork[]> {
+  const params = new URLSearchParams({ limit: '50' })
+  const response = await fetch(`${API_BASE_URL}/api/artworks?${params}`)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch user artworks (Status: ${response.status})`)
+  }
+  const data = await response.json()
+  if (!data.success) {
+    throw new Error(data?.error?.message || 'Failed to fetch user artworks')
+  }
+  // Filter client-side by creator address (backend seed data has creator field)
+  const artworks = data.data as Artwork[]
+  return creator ? artworks.filter((a) => a.creator === creator) : artworks
+}
+
+export function useUserArtworks(creator: string) {
+  return useQuery<Artwork[], Error>({
+    queryKey: ['artworks', 'user', creator],
+    queryFn: () => fetchUserArtworks(creator),
+    staleTime: 2 * 60 * 1000,
+    retry: 1,
+  })
 }


### PR DESCRIPTION
closes #28 

Resolves issue #28 — components (specifically the 

ProfilePage
) were using hardcoded mock arrays and static strings instead of fetching from the existing backend API.

Changes
📡 New API Hooks
Added two new hooks to 

services/artworkService.ts
 to connect the frontend to the backend's User and Artwork endpoints:


useUserProfile
: Fetches the artist's profile data (name, bio, stats) from GET /api/users/profile.

useUserArtworks
: Fetches all artworks and filters them by the creator's address to populate the user's gallery.
👤 ProfilePage Refactor
Completely removed the local mockArtworks array and hardcoded strings ("Artist Name", "0x1234...5678", and stats).

Identity: Now integrates with 

useStellar
. If a Freighter wallet is connected, the page displays the real public key and fetches artworks for that specific account. If not, it falls back to the backend's default profile.
Loading States: Integrated ArtworkCardSkeleton to prevent layout shift while fetching user-specific artworks.
Empty States: Uses the 

EmptyState
 component when a user has no created artworks.
🐛 TypeScript & Type Fixes
Added the missing 'no-favorites' type to the 

EmptyState
 component props and implemented its corresponding view.
Added the 

UserProfile
 interface to 

artworkService.ts
 to ensure type-safe API responses.