### PR TITLE
fix: Add CORS preflight handling for all endpoints (issue #69)

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -21,7 +21,31 @@ const PORT = process.env.PORT || 3001
 const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/muse'
 
 // Middleware
-app.use(cors())
+const allowedOrigins = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',').map((origin) => origin.trim())
+  : ['*']
+
+const corsOptions = {
+  origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+    if (!origin) {
+      // Allow non-browser requests (e.g., server-to-server)
+      return callback(null, true)
+    }
+
+    if (allowedOrigins.includes('*') || allowedOrigins.includes(origin)) {
+      return callback(null, true)
+    }
+
+    callback(new Error('Not allowed by CORS'))
+  },
+  methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization'],
+  credentials: true,
+  optionsSuccessStatus: 204,
+}
+
+app.use(cors(corsOptions))
+app.options('*', cors(corsOptions))
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 

--- a/apps/backend/src/tests/health.test.ts
+++ b/apps/backend/src/tests/health.test.ts
@@ -27,6 +27,21 @@ describe('Health Check Endpoints', () => {
       expect(summary).toHaveProperty('unhealthy')
       expect(summary).toHaveProperty('degraded')
     })
+
+    it('should respond to CORS preflight OPTIONS with allowed headers and methods', async () => {
+      const origin = 'http://localhost:3000'
+
+      const response = await request(app)
+        .options('/health')
+        .set('Origin', origin)
+        .set('Access-Control-Request-Method', 'GET')
+        .set('Access-Control-Request-Headers', 'Content-Type, Authorization')
+        .expect(204)
+
+      expect(response.header['access-control-allow-origin']).toBe(origin)
+      expect(response.header['access-control-allow-methods']).toEqual(expect.stringContaining('GET'))
+      expect(response.header['access-control-allow-headers']).toEqual(expect.any(String))
+    })
   })
 
   describe('GET /ready', () => {

--- a/mock-api.js
+++ b/mock-api.js
@@ -198,8 +198,25 @@ const PLATFORM_STATS = {
 };
 
 // Middleware
-app.use(cors());
-app.use(express.json());
+const allowedOrigins = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',').map(origin => origin.trim())
+  : ['*']
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin) return callback(null, true)
+    if (allowedOrigins.includes('*') || allowedOrigins.includes(origin)) return callback(null, true)
+    callback(new Error('Not allowed by CORS'))
+  },
+  methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept', 'Authorization'],
+  credentials: true,
+  optionsSuccessStatus: 204,
+}
+
+app.use(cors(corsOptions))
+app.options('*', cors(corsOptions))
+app.use(express.json())
 
 // Health check
 app.get('/health', (req, res) => {


### PR DESCRIPTION
closes #69 
- Configure CORS with environment-based origin allowlist
- Add explicit OPTIONS handler for preflight requests across all routes
- Support proper CORS headers: methods, allowedHeaders, credentials
- Add regression test for CORS preflight functionality
- Apply fix to backend and mock-api