### PR TITLE
feat: implement user-specific API rate limiting with anonymous tier a…

### DIFF
--- a/apps/backend/src/config/rateLimitConfig.ts
+++ b/apps/backend/src/config/rateLimitConfig.ts
@@ -1,4 +1,9 @@
 export const TIER_LIMITS = {
+  anonymous: {
+    windowMs: 15 * 60 * 1000,
+    max: 30,
+    message: 'Anonymous limit reached (30 req / 15 min). Please sign in for more.',
+  },
   free: {
     windowMs: 15 * 60 * 1000,
     max: 100,
@@ -17,6 +22,11 @@ export const TIER_LIMITS = {
 }
 
 export const AI_GENERATION_LIMITS = {
+  anonymous: {
+    windowMs: 24 * 60 * 60 * 1000,
+    max: 1,
+    message: 'Anonymous: daily AI generation limit reached (1 image). Sign in for more.',
+  },
   free: {
     windowMs: 24 * 60 * 60 * 1000,
     max: 5,

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -34,6 +34,8 @@ import { createLogger } from '@/utils/logger'
 import { websocketService } from '@/services/websocketService'
 import { ensureIndexes } from '@/scripts/ensureIndexes'
 import logsRoute from "./routes/logs";
+import { optionalAuthenticate } from '@/middleware/authMiddleware';
+import { standardLimiter } from '@/middleware/rateLimitMiddleware';
 
 dotenv.config()
 
@@ -122,6 +124,12 @@ export function createApp() {
   })
 
   // ── API Routes ───────────────────────────────────────────────────────────────
+  // Apply optional authentication globally to populate req.user for rate limiting
+  app.use('/api', optionalAuthenticate)
+  
+  // Apply baseline rate limiting to all API endpoints
+  app.use('/api', standardLimiter)
+
   app.use('/api/auth', authRoutes)
   app.use('/api/artworks', artworkRoutes)
   app.use('/api/users', userRoutes)

--- a/apps/backend/src/middleware/authMiddleware.ts
+++ b/apps/backend/src/middleware/authMiddleware.ts
@@ -12,7 +12,7 @@ export interface AuthRequest extends Request {
   user?: {
     id: string
     address: string
-    tier: 'free' | 'pro' | 'premium'
+    tier: 'anonymous' | 'free' | 'pro' | 'premium'
     [key: string]: any
   }
 }

--- a/apps/backend/src/middleware/rateLimitMiddleware.ts
+++ b/apps/backend/src/middleware/rateLimitMiddleware.ts
@@ -9,15 +9,18 @@ import { AuthRequest } from './authMiddleware'
 export const standardLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: (req: AuthRequest) => {
-    const tier = req.user?.tier || 'free'
-    return TIER_LIMITS[tier as keyof typeof TIER_LIMITS].max
+    const tier = req.user?.tier || 'anonymous'
+    const limits = TIER_LIMITS[tier as keyof typeof TIER_LIMITS] || TIER_LIMITS.anonymous
+    return limits.max
   },
   keyGenerator: (req: AuthRequest) => {
+    // Priority: User Address > IP Address
     return req.user?.address || req.ip || 'anonymous'
   },
   message: (req: AuthRequest) => {
-    const tier = req.user?.tier || 'free'
-    return TIER_LIMITS[tier as keyof typeof TIER_LIMITS].message
+    const tier = req.user?.tier || 'anonymous'
+    const limits = TIER_LIMITS[tier as keyof typeof TIER_LIMITS] || TIER_LIMITS.anonymous
+    return limits.message
   },
   standardHeaders: true,
   legacyHeaders: false,
@@ -29,15 +32,17 @@ export const standardLimiter = rateLimit({
 export const aiGenerationLimiter = rateLimit({
   windowMs: 24 * 60 * 60 * 1000, // 24 hours
   max: (req: AuthRequest) => {
-    const tier = req.user?.tier || 'free'
-    return AI_GENERATION_LIMITS[tier as keyof typeof AI_GENERATION_LIMITS].max
+    const tier = req.user?.tier || 'anonymous'
+    const limits = AI_GENERATION_LIMITS[tier as keyof typeof AI_GENERATION_LIMITS] || AI_GENERATION_LIMITS.anonymous
+    return limits.max
   },
   keyGenerator: (req: AuthRequest) => {
     return req.user?.address || req.ip || 'anonymous'
   },
   message: (req: AuthRequest) => {
-    const tier = req.user?.tier || 'free'
-    return AI_GENERATION_LIMITS[tier as keyof typeof AI_GENERATION_LIMITS].message
+    const tier = req.user?.tier || 'anonymous'
+    const limits = AI_GENERATION_LIMITS[tier as keyof typeof AI_GENERATION_LIMITS] || AI_GENERATION_LIMITS.anonymous
+    return limits.message
   },
   standardHeaders: true,
   legacyHeaders: false,

--- a/apps/backend/src/routes/user.ts
+++ b/apps/backend/src/routes/user.ts
@@ -14,13 +14,12 @@ import {
   authenticate,
   optionalAuthenticate,
 } from "@/middleware/authMiddleware";
-import { standardLimiter } from "@/middleware/rateLimitMiddleware";
 
 const router = Router();
 
 router.get("/:address", optionalAuthenticate, getProfile);
 router.get("/id/:id", getProfileById);
-router.put("/:address", authenticate, standardLimiter, updateProfile);
+router.put("/:address", authenticate, updateProfile);
 router.delete("/:address", authenticate, deleteProfile);
 router.put("/:address/preferences", authenticate, updatePreferences);
 router.get("/:address/activity", getUserActivity);


### PR DESCRIPTION
# User-Specific API Rate Limiting - Resolves Issue #167

Implements a robust rate-limiting system with different tiers for authenticated vs. anonymous users.

##  What's Included
- **Anonymous Tier**: Added a new tier for unauthenticated users with stricter limits (30 req / 15 min).
- **Dynamic Tier Selection**: Rate limiters now automatically adjust based on the user's tier (`anonymous`, `free`, `pro`, `premium`).
- **Global Enforcement**: Applied baseline rate limiting globally to all `/api` routes via `index.ts`.
- **Improved Key Generation**: Uses the user's wallet address as the unique identifier when authenticated, falling back to IP address for anonymous users.
- **Redundancy Cleanup**: Removed redundant rate limiters from individual routes.

## Verification
- Updated `rateLimitConfig.ts` with new tier definitions.
- Refined `rateLimitMiddleware.ts` for dynamic limit application.
- Verified global middleware ordering in `index.ts`.

##  Closes #167 
